### PR TITLE
Limit pigpiox dependency to Raspberry Pi targets

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule NervesLivebook.MixProject do
       {:circuits_gpio, "~> 0.4", targets: @all_targets},
       {:circuits_i2c, "~> 0.3", targets: @all_targets},
       {:circuits_spi, "~> 0.1", targets: @all_targets},
-      {:pigpiox, "~>0.1"},
+      {:pigpiox, "~>0.1", targets: [:rpi, :rpi0, :rpi2, :rpi3, :rpi3a, :rpi4]},
       {:power_control, github: "cjfreeze/power_control", targets: @all_targets},
       {:ramoops_logger, "~> 0.1", targets: @all_targets},
       {:bmp280, "~> 0.2", targets: @all_targets},


### PR DESCRIPTION
This PR fixes an application crash due to a failure to start `pigpiox` on non-`rpi` Nerves targets:

```
15:17:35.667 [info]  Application pigpiox exited: Pigpiox.Application.start(:normal, []) returned an error: shutdown: failed to start child: Pigpiox.Port
    ** (EXIT) an exception was raised:
        ** (ErlangError) Erlang error: :enoent
            :erlang.open_port({:spawn_executable, nil}, [:binary, :exit_status, {:args, ["-g", "-x", "-1"]}])
            (pigpiox 0.1.2) lib/pigpiox/port.ex:21: Pigpiox.Port.init/1
            (stdlib 3.14.1) gen_server.erl:417: :gen_server.init_it/2
            (stdlib 3.14.1) gen_server.erl:385: :gen_server.init_it/6
            (stdlib 3.14.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```