### PR TITLE
Add support for provisioning WiFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,18 @@ Success!
 Elapsed time: 3.595 s
 ```
 
-Now you have Nerves ready to run on your device. Skip ahead to the next
+If you're using a WiFi-enabled device and want the WiFi credentials to be
+written to the MicroSD card, initialize the MicroSD card like this instead:
+
+```sh
+sudo NERVES_WIFI_SSID='access_point' NERVES_WIFI_PASSPHRASE='passphrase' fwup nerves_livebook_rpi0.fw
+```
+
+You can still change the WiFi credentials at runtime using
+`VintageNetWiFi.quick_configure/2`, but this helps you don't have an easy
+alternative way of accessing the device to configure WiFi.
+
+Now you have Nerves Livebook ready to run on your device. Skip ahead to the next
 section.
 
 ### `etcher`
@@ -77,6 +88,10 @@ Start [`etcher`](https://www.etcher.net/), point it to the zip file, and follow
 the prompts:
 
 ![etcher screenshot](assets/etcher.png)
+
+IMPORTANT: There's no way to configure the initial WiFi credentials with
+`etcher`. If you have a device that you can only access via WiFi (so no way of
+setting credentials), then check out the `fwup` instructions above.
 
 ## Running the Firmware
 
@@ -91,7 +106,7 @@ is "nerves".
 
 ## Going further
 
-At some point you'll want to create your own firmware. See the [Nerves
+At some point you may want to customize Nerves Livebook. See the [Nerves
 Installation](https://hexdocs.pm/nerves/installation.html) and [Getting
 Started](https://hexdocs.pm/nerves/getting-started.html) guides for details.
 
@@ -111,7 +126,28 @@ $ mix firmware
 # Option 1: Insert a MicroSD card
 $ mix burn
 
-# Options 2: Upload to an existing Nerves Livebook device
+# Option 2: Upload to an existing Nerves Livebook device
 $ mix firmware.gen.script
 $ ./upload.sh nerves.local
 ```
+
+## Firmware provisioning options
+
+Nerves Livebook supports some device-specific customization after the firmware
+has been created. This means that you don't need to rebuild the firmware to set
+any of the options in this section. Instead, they are set when you use `fwup` to
+initialize a MicroSD card. Here's an example invocation of `fwup` to show what
+to do:
+
+```sh
+sudo NERVES_WIFI_SSID='access_point' NERVES_WIFI_PASSPHRASE='passphrase' fwup nerves_livebook_rpi0.fw
+```
+
+See the `config/provisioning.conf` for details. Here is a summary of the options:
+
+Environment variable | Nerves.Runtime.KV key | Description
+ ------------------- | --------------------- | -----------
+NERVES_SERIAL_NUMBER | nerves_serial_number  | Set the device serial number to the specified text (default is to use device-specific unique ID)
+NERVES_WIFI_FORCE    | wifi_force            | Set to `true` to always set WiFi credentials on boot even if other ones were previously set
+NERVES_WIFI_PASSPHRASE | wifi_passphrase     | A WiFi passphrase to use if WiFi hasn't been configured
+NERVES_WIFI_SSID     | wifi_ssid             | A WiFi SSID to use if WiFi hasn't been configured

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,7 +28,9 @@ config :livebook,
 # Customize non-Elixir parts of the firmware. See
 # https://hexdocs.pm/nerves/advanced-configuration.html for details.
 
-config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
+config :nerves, :firmware,
+  rootfs_overlay: "rootfs_overlay",
+  provisioning: "config/provisioning.conf"
 
 # Set the SOURCE_DATE_EPOCH date for reproducible builds.
 # See https://reproducible-builds.org/docs/source-date-epoch/ for more information

--- a/config/provisioning.conf
+++ b/config/provisioning.conf
@@ -1,0 +1,21 @@
+# Support setting the initial WiFi credentials when creating MicroSD cards.
+#
+# Note that the '$' is escaped so that environment variable replacement happens
+# when firmware is written to the MicroSD card rather than when the '.fw' file
+# is created.  WiFi credentials are not stored in the .fw file. If left blank,
+# the device won't connect to WiFi and you'll need to configure it in Livebook
+# or via an iex prompt.
+#
+# IMPORTANT: If you configure WiFi in Livebook or via the IEx prompt, that
+# configuration will be persisted and these won't be used unless
+# $NERVES_WIFI_FORCE is set to "true" (or anything)
+uboot_setenv(uboot-env, "wifi_ssid", "\${NERVES_WIFI_SSID}")
+uboot_setenv(uboot-env, "wifi_passphrase", "\${NERVES_WIFI_PASSPHRASE}")
+uboot_setenv(uboot-env, "wifi_force", "\${NERVES_WIFI_FORCE}")
+
+# Normally the serial number comes from a unique device ID on the board.  Use
+# this to override the default serial number. The serial number is used to
+# determine the hostname so overriding the serial number can be convenient for
+# naming devices.
+uboot_setenv(uboot-env, "nerves_serial_number", "\${NERVES_SERIAL_NUMBER}")
+

--- a/lib/nerves_livebook/application.ex
+++ b/lib/nerves_livebook/application.ex
@@ -7,6 +7,8 @@ defmodule NervesLivebook.Application do
 
   def start(_type, _args) do
     initialize_data_directory()
+    setup_wifi()
+
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: NervesLivebook.Supervisor]
@@ -36,4 +38,19 @@ defmodule NervesLivebook.Application do
     _ = File.rm(dest)
     _ = File.ln_s(source, dest)
   end
+
+  defp setup_wifi() do
+    kv = Nerves.Runtime.KV.get_all()
+
+    if true?(kv["wifi_force"]) or VintageNet.get_configuration("wlan0") == %{type: VintageNetWiFi} do
+      _ = VintageNetWiFi.quick_configure(kv["wifi_ssid"], kv["wifi_passphrase"])
+      :ok
+    end
+  end
+
+  defp true?(""), do: false
+  defp true?(nil), do: false
+  defp true?("false"), do: false
+  defp true?("FALSE"), do: false
+  defp true?(_), do: true
 end


### PR DESCRIPTION
This is a way for provisioning WiFi credentials without using AP mode or requiring the user to build their own firmware.