### PR TITLE
Support books that use Mix.install/1

### DIFF
--- a/lib/nerves_livebook/application.ex
+++ b/lib/nerves_livebook/application.ex
@@ -8,6 +8,7 @@ defmodule NervesLivebook.Application do
   def start(_type, _args) do
     initialize_data_directory()
     setup_wifi()
+    add_mix_install()
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
@@ -53,4 +54,16 @@ defmodule NervesLivebook.Application do
   defp true?("false"), do: false
   defp true?("FALSE"), do: false
   defp true?(_), do: true
+
+  defp add_mix_install() do
+    # This needs to be done this way since redefining Mix at compile time
+    # doesn't make anyone happy.
+    Code.eval_string("""
+    defmodule Mix do
+      def install(deps, opts \\\\ []) when is_list(deps) and is_list(opts) do
+        NervesLivebook.MixInstall.install(deps, opts)
+      end
+    end
+    """)
+  end
 end

--- a/lib/nerves_livebook/mix_install.ex
+++ b/lib/nerves_livebook/mix_install.ex
@@ -1,0 +1,77 @@
+defmodule NervesLivebook.MixInstall do
+  @moduledoc """
+  Simulate Mix.install for Nerves Livebook
+
+  Nerves Livebook currently doesn't support `Mix.install/1`, but hopefully it
+  will in the future. As a workaround, check whether dependencies that the user
+  specifies are available and give them a help message if not.
+  """
+
+  @spec install([atom() | {atom(), keyword()} | {atom(), binary(), keyword()}], keyword()) :: :ok
+  def install(deps, opts) when is_list(deps) and is_list(opts) do
+    deps
+    |> Enum.map(&normalize/1)
+    |> Enum.each(&check_dep/1)
+  end
+
+  defp normalize(app) when is_atom(app), do: {app, ">= 0.0.0"}
+
+  defp normalize({app, opts}) when is_atom(app) and is_list(opts) do
+    check_for_path_dep(app, opts)
+    {app, ">= 0.0.0"}
+  end
+
+  defp normalize({app, requirement}) when is_atom(app) and is_binary(requirement) do
+    {app, requirement}
+  end
+
+  defp normalize({app, requirement, opts})
+       when is_atom(app) and is_binary(requirement) and is_list(opts) do
+    check_for_path_dep(app, opts)
+    {app, requirement}
+  end
+
+  defp normalize(other) do
+    raise RuntimeError, """
+    Don't know how to install #{inspect(other)}.
+    """
+  end
+
+  defp check_for_path_dep(app, opts) do
+    if Keyword.has_key?(opts, :path) do
+      raise RuntimeError, """
+      Path dependency for #{inspect(app)} is not supported in Nerves Livebook.
+      """
+    end
+  end
+
+  defp check_dep({app, requirement}) do
+    case Application.spec(app, :vsn) do
+      nil ->
+        raise RuntimeError, """
+        Mix.install is not supported on Nerves Livebook (yet!).
+
+        All is not lost, but you will have to rebuild the Nerves Livebook firmware.
+        Go to https://github.com/fhunleth/nerves_livebook and clone the repository.
+        Add #{inspect(app)} to the dependencies listed in the `mix.exs` file, build,
+        and then try again.
+        """
+
+      vsn ->
+        Version.match?(to_string(vsn), requirement) ||
+          raise RuntimeError, """
+          The dependency #{inspect(app)} is installed in Nerves Livebook but it
+          doesn't match the version requirement #{inspect(requirement)}.
+
+          Here are ways to fix this:
+
+          1. Change the version requirement to {#{inspect(app)}, "~> #{vsn}"}
+          2. Rebuild the Nerves Livebook firmware and update the version in
+             its mix.exs.
+
+          If Nerves Livebook includes an old version, please file a PR so that
+          we can update it.
+          """
+    end
+  end
+end

--- a/test/nerves_livebook/mix_install_test.exs
+++ b/test/nerves_livebook/mix_install_test.exs
@@ -1,0 +1,20 @@
+defmodule NervesLivebook.MixInstallTest do
+  use ExUnit.Case
+  alias NervesLivebook.MixInstall
+
+  test "already installed dependencies" do
+    assert :ok == MixInstall.install([:kino, {:vega_lite, "~> 0.1.0"}], [])
+  end
+
+  test "raises on uninstalled dependency" do
+    assert_raise RuntimeError, fn ->
+      MixInstall.install([:not_a_real_package], [])
+    end
+  end
+
+  test "raises on dependency with unsupported requirement" do
+    assert_raise RuntimeError, fn ->
+      MixInstall.install([{:kino, "~> 1000.0.0"}], [])
+    end
+  end
+end


### PR DESCRIPTION
Even though Mix.install/1 isn't supported by Nerves Livebook, we can
check that what the book installs is available and give a helpful error
message if not.
