### PR TITLE
Setup Erlang distribution to use mDNS

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -19,11 +19,8 @@ config :livebook,
   default_runtime: {Livebook.Runtime.Embedded, []},
   authentication_mode: :password,
   token_authentication: false,
-  password: System.get_env("LIVEBOOK_PASSWORD", "nerves")
-
-config :livebook,
-       :cookie,
-       :nerves_livebook_cookie
+  password: System.get_env("LIVEBOOK_PASSWORD", "nerves"),
+  cookie: :nerves_livebook_cookie
 
 # Customize non-Elixir parts of the firmware. See
 # https://hexdocs.pm/nerves/advanced-configuration.html for details.

--- a/config/target.exs
+++ b/config/target.exs
@@ -5,7 +5,7 @@ import Config
 # involved with firmware updates.
 
 config :shoehorn,
-  init: [:nerves_runtime, :nerves_pack],
+  init: [:nerves_runtime, :nerves_pack, {NervesLivebook, :setup_distribution, []}],
   app: Mix.Project.config()[:app]
 
 # Use Ringlogger as the logger backend and remove :console.

--- a/lib/nerves_livebook.ex
+++ b/lib/nerves_livebook.ex
@@ -3,6 +3,8 @@ defmodule NervesLivebook do
   Nerves Livebook firmware
   """
 
+  require Logger
+
   @doc """
   Return the mix target that was used to build this firmware
 
@@ -34,5 +36,22 @@ defmodule NervesLivebook do
       do: raise("Please check that at least one network interface can reach the internet")
 
     :ok
+  end
+
+  @doc """
+  Setup Erlang distribution
+
+  This is called by Shoehorn. See `config/target.exs`.
+  """
+  @spec setup_distribution() :: :ok
+  def setup_distribution() do
+    with {_, 0} <- System.cmd("epmd", ["-daemon"]),
+         {:ok, hostname} <- :inet.gethostname(),
+         {:ok, _pid} <- Node.start(:"livebook@#{hostname}.local") do
+      # Livebook always sets the cookie, so let it set it. See the Livebook application config.
+      :ok
+    else
+      _ -> Logger.error("Unexpected error setting up Erlang distribution")
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -83,9 +83,6 @@ defmodule NervesLivebook.MixProject do
   def release do
     [
       overwrite: true,
-      # Erlang distribution is not started automatically.
-      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
-      cookie: "#{@app}_cookie",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],
       strip_beams: [keep: ["Docs"]]


### PR DESCRIPTION
This sets up Erlang distribution so that the name is predictable and
reachible using mDNS. Currently, it is hardcoded to
`livebook@hostname.local` where `hostname` is `nerves-<board id>`.

The cookie hasn't changed from before. Code was just cleaned up in this
area.
